### PR TITLE
Changed footnotes to block quote notes

### DIFF
--- a/src/examples/electrostatics.md
+++ b/src/examples/electrostatics.md
@@ -5,13 +5,13 @@ adaptive refinement, and provides a useful example of how to cast a
 problem that is normally thought of as solving a PDE as an optimization
 problem.
 
-Suppose we want to solve Laplace's equation, 
+Suppose we want to solve Laplace's equation,
 
-$$\nabla^{2}\phi=0$$ 
+$$\nabla^{2}\phi=0$$
 
 on a square domain \\(C\\) defined by \\(-L/2\leq x\leq L/2\\) and
-\\(-L/2\leq y\leq L/2\\). An equivalent formulation suitable for *morpho* is
-to minimize, 
+\\(-L/2\leq y\leq L/2\\). An equivalent formulation suitable for _morpho_ is
+to minimize,
 
 $$
 \begin{equation}
@@ -22,15 +22,13 @@ $$
 
 with respect to \\(\phi\\).
 
-
 We can show the two are equivalent by applying calculus of
-variations[^9] to the \eqref{eq:el1},
+variations to the \eqref{eq:el1},
 
-$$ \delta\int_{C}\left|\nabla\phi\right|^{2}dA =\int_{C}\delta\left|\nabla\phi\right|^{2}dA $$
-$$ =\int_{C}\frac{\partial}{\partial\nabla\phi}\left|\nabla\phi\right|^{2}\cdot\delta\nabla\phi dA,$$ 
+$$ \delta\int*{C}\left|\nabla\phi\right|^{2}dA =\int*{C}\delta\left|\nabla\phi\right|^{2}dA $$
+$$ =\int\_{C}\frac{\partial}{\partial\nabla\phi}\left|\nabla\phi\right|^{2}\cdot\delta\nabla\phi dA,$$
 
-and integrating by parts, 
-
+and integrating by parts,
 
 $$
 \begin{align}
@@ -38,6 +36,8 @@ $$
  & =\int_{\partial C}\nabla\phi\cdot\hat{\mathbf{s}}\delta\phi dl-\int_{C}\nabla^{2}\phi\delta\phi dA,\label{eq:bulkvariations}
 \end{align}
 $$
+
+> **Note** If you're not familiar with calculus of variations, feel free to skip paragraphs that refer to "variations". The calculus of variations generalizes calculus from differentiating with respect to variables to differentiating with respect to functions.
 
 where \\(\hat{\mathbf{s}}\\) is the outward normal. Hence,
 allowing for arbitrary variations \\(\delta\phi\\), in order for the bulk
@@ -57,8 +57,9 @@ $$
 \lambda\int_{\partial C}\left[\phi-\phi_{0}(\mathbf{x})\right]^{2}dl\label{eq:anchoring}
 \end{equation}
 $$
-where the function \\(\phi_{0}\\) represents some imposed boundary
-potential. Taking variations of this functional, 
+
+where the function \\(\phi\_{0}\\) represents some imposed boundary
+potential. Taking variations of this functional,
 
 $$
 \begin{align}
@@ -71,12 +72,12 @@ Collecting the boundary terms from \eqref{eq:bulkvariations} and \eqref{eq:bound
 on \\(\phi\\),
 $$\nabla\phi\cdot\hat{\mathbf{s}}+2\lambda(\phi-\phi_{0})=0,$$ which is
 known as a Robin boundary condition. As \\(\lambda\to\infty\\),
-\\(\phi\to\phi_{0}\\) on the boundary, recovering a fixed boundary or
+\\(\phi\to\phi_0\\) on the boundary, recovering a fixed boundary or
 Dirichlet condition, while as \\(\lambda\to0\\), we recover the Neumann
 conditions discussed earlier.
 
-In the example, we will set \\(\phi_{0}=0\\) on the left and lower boundary
-and \\(\phi_{0}=1\\) on the right and upper boundary, and use \\(\lambda=100\\).
+In the example, we will set \\(\phi_0=0\\) on the left and lower boundary
+and \\(\phi_0=1\\) on the right and upper boundary, and use \\(\lambda=100\\).
 
 The code illustrates a few *morpho* tricks. First, the following code is
 used to select the left/bottom and upper/right sides of the mesh:
@@ -105,7 +106,7 @@ The problem setup involves adding the electrostatic energy Eq.\eqref{eq:el1} usi
     var lt1 = LineIntegral(fn (x, v) (v-v1)^2, phi)
     problem.addenergy(lt1, selection=bnd1, prefactor=100)
     var lt2 = LineIntegral(fn (x, v) (v-v2)^2, phi)
-    problem.addenergy(lt2, selection=bnd2, prefactor=100) 
+    problem.addenergy(lt2, selection=bnd2, prefactor=100)
 
 Optimization is done with a `FieldOptimizer`:
 
@@ -124,11 +125,11 @@ is changingand find the mean energy per element. We then create a
 Selection and manually select elements that have an electrostatic energy
 more than \\(1.5\times\\) the mean.
 
-    // Select elements that have an above average contribution to the energy 
+    // Select elements that have an above average contribution to the energy
     var en = le.integrand(phi) // energy in each element
     var mean = en.sum()/en.count() // mean energy per element
     var srefine = Selection(mesh)
-    for (id in 0...en.count()) if (en[0,id]>1.5*mean) srefine[2,id]=true 
+    for (id in 0...en.count()) if (en[0,id]>1.5*mean) srefine[2,id]=true
     // identify large contributions
 
 Refinement is then performed with a MeshRefiner object from the
@@ -184,4 +185,3 @@ square domain</strong> (left) mesh after 10 iterations of adaptive
 refinement and optimization and (right) the resulting solution. Grade 1
 elements are shown to emphasize the mesh structure.</figcaption>
 </figure>
-

--- a/src/installing_morpho.md
+++ b/src/installing_morpho.md
@@ -1,18 +1,18 @@
-# Installing *Morpho*
+# Installing _Morpho_
 
-*Morpho* is hosted on a publicly available github repository
+_Morpho_ is hosted on a publicly available github repository
 <https://github.com/Morpho-lang/morpho>. We are continuously working on
-improving *morpho* installation. With this release, *morpho* on macOS
+improving _morpho_ installation. With this release, _morpho_ on macOS
 now has a streamlined installation process using homebrew. Other
 platforms must be installed from source and we hope to provide packages
 for future releases. Instructions for different platforms are provided
 below.
 
-### Where *morpho* installation puts things
+### Where _morpho_ installation puts things
 
-A *morpho* installation includes help files, modules, and other
+A _morpho_ installation includes help files, modules, and other
 resources. By default, these are installed in the **/usr/local/** file
-structure[^1], including in the following places:
+structure, including in the following places:
 
 **/usr/local/bin** : The morpho and morphoview executables are placed here.
 
@@ -22,7 +22,9 @@ structure[^1], including in the following places:
 
 **/usr/local/lib/morpho** : Morpho extensions.
 
-It's possible to build *morpho* to use different locations for resources
+> **Note**: On the macOS, these files are contained within the homebrew system.
+
+It's possible to build _morpho_ to use different locations for resources
 and the binary. To do so, set the `MORPHORESOURCESDIR` option when you
 run make, e.g.
 
@@ -30,19 +32,21 @@ run make, e.g.
 
 where X is the base folder you wish to use, i.e. the replacement for
 **/usr/local**. Subfolders will be created by the installer. To control
-where the *morpho* binary is placed, also set the `DESTDIR` option,
+where the _morpho_ binary is placed, also set the `DESTDIR` option,
 
     sudo make MORPHORESOURCESDIR=X DESTDIR=Y install
 
 ### Dependencies
 
-*Morpho* leverages a few libraries to provide certain functionality:
+_Morpho_ leverages a few libraries to provide certain functionality:
 
 **glfw** : is used to provide gui functionality for an interactive visualization application, `morphoview`.
 
 **blas/lapack** : are used for dense linear algebra.
 
-**suitesparse** : is used for sparse linear algebra[^2].
+**suitesparse** : is used for sparse linear algebra.
+
+> See <https://people.engr.tamu.edu/davis/suitesparse.html> and publications for details
 
 **freetype** : provides text display.
 
@@ -54,7 +58,7 @@ The recommended approach to installing morpho on macOS is to use the
 [Homebrew](https://brew.sh) package manager.
 
 1.  If you have a previous installation of morpho, we recommend you
-    remove it by following the instructions for uninstalling *morpho*
+    remove it by following the instructions for uninstalling _morpho_
     below.
 
 2.  Install [Homebrew](https://brew.sh), following instructions on the
@@ -109,10 +113,12 @@ with the sudo command:
         git clone https://github.com/Morpho-lang/morpho.git
 
 5.  Navigate to the `morpho5` folder within the downloaded repository
-    and build the application[^3]
+    and build the application
 
         cd morpho/morpho5
         make -f Makefile.m1 install
+
+> Some users may need to use `sudo make install`
 
 6.  Navigate to the `morphoview` folder and build the viewer application
 
@@ -142,7 +148,7 @@ distributions you will need to find the equivalent packages.
 
         sudo apt install build-essential
 
-3.  Install *morpho*'s dependencies using your distribution's package
+3.  Install _morpho_'s dependencies using your distribution's package
     manager (or manually if you prefer):
 
         sudo apt install libglfw3-dev libsuitesparse-dev liblapacke povraylibfreetype6-dev
@@ -178,7 +184,7 @@ Follow all the steps in this link to ensure that graphics are working.
 
 #### Install Morpho
 
-Once the Ubuntu terminal is working in Windows, you can install *morpho*
+Once the Ubuntu terminal is working in Windows, you can install _morpho_
 the same way as in Linux by running the commands in the instructions in
 the Ubuntu terminal.
 
@@ -217,10 +223,10 @@ the commands below are run in the Ubuntu terminal.
 
     To set the DISPLAY variable on login type
 
-        echo export DISPLAY=localhost:0 >> ~/.bashrc 
+        echo export DISPLAY=localhost:0 >> ~/.bashrc
 
-    *\[Note that this assumes you are using bash as your terminal; you
-    will may to adjust this line for other terminals\].*
+    _\[Note that this assumes you are using bash as your terminal; you
+    will may to adjust this line for other terminals\]._
 
 4.  Test that the window system is working by running
 
@@ -239,47 +245,45 @@ the commands below are run in the Ubuntu terminal.
     and minimizing electric potential. It should generate an interactive
     figure of points on a sphere.
 
-### Updating *morpho*
+### Updating _morpho_
 
-As new versions of *morpho* are released, you will likely want to
+As new versions of _morpho_ are released, you will likely want to
 upgrade to the latest version. From the terminal:
 
--   If you used homebrew to install morpho, simply type,
+- If you used homebrew to install morpho, simply type,
 
-        brew upgrade morpho
+      brew upgrade morpho
 
--   If you installed *morpho* manually, and still have the git
-    repository folder on your computer, navigate to this with `cd` and
-    type,
+- If you installed _morpho_ manually, and still have the git
+  repository folder on your computer, navigate to this with `cd` and
+  type,
 
-        git pull
+      git pull
 
-    which downloads any updates. You can then follow the above
-    instructions to recompile *morpho.* It's not necessary to reinstall
-    dependencies, but note that some new releases of *morpho* may
-    require additional dependencies.
+  which downloads any updates. You can then follow the above
+  instructions to recompile _morpho._ It's not necessary to reinstall
+  dependencies, but note that some new releases of _morpho_ may
+  require additional dependencies.
 
--   If you no longer have the original *morpho* git repository folder
-    from which you installed morpho, simply rerun the installation from
-    scratch as above. You shouldn't need to reinstall dependencies.
+- If you no longer have the original _morpho_ git repository folder
+  from which you installed morpho, simply rerun the installation from
+  scratch as above. You shouldn't need to reinstall dependencies.
 
-### Uninstalling *morpho*
+### Uninstalling _morpho_
 
 If you wish to uninstall morpho, you can do so simply from the terminal
 application.
 
--   If you used homebrew to install morpho, simply type
+- If you used homebrew to install morpho, simply type
 
-        brew uninstall morpho
+      brew uninstall morpho
 
--   Alternatively, if you did a manual install, you can remove
-    everything with
+- Alternatively, if you did a manual install, you can remove
+  everything with
 
-        rm /usr/local/bin/morpho
-        rm /usr/local/bin/morphoview
-        rm -r /usr/local/share/morpho
-        rm -r /usr/local/lib/morpho
+      rm /usr/local/bin/morpho
+      rm /usr/local/bin/morphoview
+      rm -r /usr/local/share/morpho
+      rm -r /usr/local/lib/morpho
 
-    You may need to prefix these with `sudo`.
-
-[^1]: On the macOS, these files are contained within the homebrew system
+  You may need to prefix these with `sudo`.

--- a/src/tutorial/refinement.md
+++ b/src/tutorial/refinement.md
@@ -5,7 +5,7 @@ complete problem script is provided in the `examples/tutorial` folder
 inside the git repository as `tutorial.morpho`. The result we have
 obtained in Fig. [4.5](#fig:FinalResult) is, however, a very coarse, low resolution
 solution comprising only a relatively small number of elements. To gain
-an improved solution, we need to *refine* our mesh. Because modifying
+an improved solution, we need to _refine_ our mesh. Because modifying
 the mesh also requires us to update other data structures like fields
 and selections, a special `MeshRefiner` object is used to perform the
 refinement.
@@ -16,24 +16,26 @@ To perform refinement we:
     `Mesh`, `Field` and `Selection` objects (i.e. the mesh and objects
     that directly depend on it) that need to be updated:
     ```javascript
-    var mr=MeshRefiner([m, nn, bnd]) // Set the refiner up
+    var mr = MeshRefiner([m, nn, bnd]); // Set the refiner up
     ```
 2.  Call the `refine` method on the `MeshRefiner` object to actually
     perform the refinement. This method returns a `Dictionary` object
     that maps the old objects to potentially newly created ones.
     ```javascript
-    var refmap=mr.refine() // Perform the refinement
+    var refmap = mr.refine(); // Perform the refinement
     ```
 3.  Tell any other objects that refer to the mesh, fields or selections
     to update their references using `refmap`. For example,
     `OptimizationProblem` and `Optimizer` objects are typically updated
     at this step.
     ```javascript
-    for (el in [problem, sopt, fopt]) el.update(refmap) // Update the problem
+    for (el in [problem, sopt, fopt]) el.update(refmap); // Update the problem
     ```
 4.  Update our own references
     ```javascript
-    m=refmap[m]; nn=refmap[nn]; bnd=refmap[bnd] // Update variables
+    m = refmap[m];
+    nn = refmap[nn];
+    bnd = refmap[bnd]; // Update variables
     ```
 
 <figure id="fig:Refinement">
@@ -47,19 +49,22 @@ successive levels of refinement.</figcaption>
 </figure>
 
 We insert this code after our optimization section, which causes
-*morpho* to successively optimize and refine[^4]. The resulting
-optimized shapes are displayed in Fig.
-[4.6](#fig:Refinement).
+_morpho_ to successively optimize and refine.
+
+> The complete code including refinement is in `examples/tutorial` folder inside the git repository as `tutorial2.morpho`
+
+The resulting
+optimized shapes are displayed in Fig. [4.6](#fig:Refinement).
 
     // Optimization loop
     var refmax = 3
     for (refiter in 1..refmax) {
       print "===Refinement level ${refiter}==="
       for (i in 1..100) {
-        fopt.linesearch(20)     
-        sopt.linesearch(20)   
+        fopt.linesearch(20)
+        sopt.linesearch(20)
       }
-     
+
       if (refiter==refmax) break
 
       // Refinement

--- a/src/visualization/graphics_module.md
+++ b/src/visualization/graphics_module.md
@@ -5,60 +5,63 @@ which you can use this to create custom visualizations and generate
 other kinds of graphical output. These can be easily combined with
 output from the `plot` module, which utilizes `graphics` internally.
 
-We begin by creating a Graphics object, which represents a *scene* or a
+We begin by creating a Graphics object, which represents a _scene_ or a
 collection of things to be displayed.
 
     var g = Graphics()
 
-Once the Graphics object is created, we can add *display elements*[^8],
-objects specifying what is to be drawn, to the scene in turn. The
-graphics module supports the following kinds of element:
+Once the Graphics object is created, we can add _display elements_,
+objects specifying what is to be drawn, to the scene in turn.
 
--   **Cylinder** specified by two points at each end of the cylinder on
-    its axis. You can also specify the aspect ratio, i.e. the ratio of
-    the radius of the cylinder to its length, and the number of points
-    to draw.
+> Sometimes referred to as graphics 'primitives'.
 
-        Cylinder([-1/2,-1/2,-1/2], [1/2,1/2,1/2], aspectratio=0.2, n=10)
+The graphics module supports the following kinds of element:
 
--   **Arrow** specified in the same way as a Cylinder, e.g.
+- **Cylinder** specified by two points at each end of the cylinder on
+  its axis. You can also specify the aspect ratio, i.e. the ratio of
+  the radius of the cylinder to its length, and the number of points
+  to draw.
 
-        Arrow([-1/2,-1/2,-1/2], [1/2,1/2,1/2], aspectratio=0.2, n=10)
+      Cylinder([-1/2,-1/2,-1/2], [1/2,1/2,1/2], aspectratio=0.2, n=10)
 
--   **Sphere** specified by the center and the radius, e.g.
+- **Arrow** specified in the same way as a Cylinder, e.g.
 
-        Sphere([0,0,0], 0.8)
+      Arrow([-1/2,-1/2,-1/2], [1/2,1/2,1/2], aspectratio=0.2, n=10)
 
--   **Text** specified by the text to display and the location to
-    display at. Many options can be provided, including the drawing
-    direction and the vertical direction, the size in points (1 graphics
-    unit=72 points), and the Font.
+- **Sphere** specified by the center and the radius, e.g.
 
-        Text("Hello World!", [-0.75,0,0], size=24, color=Black)
+      Sphere([0,0,0], 0.8)
 
--   **Tube** specified by a sequence of points and a radius. You can
-    also specify if the tube is closed or not.
+- **Text** specified by the text to display and the location to
+  display at. Many options can be provided, including the drawing
+  direction and the vertical direction, the size in points (1 graphics
+  unit=72 points), and the Font.
 
-        var pts = []
-        for (phi in -Pi..Pi:Pi/32) {
-            pts.append([0.5*(1+0.3*sin(4*phi))*cos(phi), 0.5*(1+0.3*sin(4*phi))*sin(phi), 0]) 
-        }
-        g.display(Tube(pts, 0.05, color=Blue, closed=true))
+      Text("Hello World!", [-0.75,0,0], size=24, color=Black)
 
--   **TriangleComplex** describes a collection of triangles, which can
-    be used to display polyhedra and other complex objects. These
-    elements are low-level, and further information is available in the
-    reference section.
+- **Tube** specified by a sequence of points and a radius. You can
+  also specify if the tube is closed or not.
+
+      var pts = []
+      for (phi in -Pi..Pi:Pi/32) {
+          pts.append([0.5*(1+0.3*sin(4*phi))*cos(phi), 0.5*(1+0.3*sin(4*phi))*sin(phi), 0])
+      }
+      g.display(Tube(pts, 0.05, color=Blue, closed=true))
+
+- **TriangleComplex** describes a collection of triangles, which can
+  be used to display polyhedra and other complex objects. These
+  elements are low-level, and further information is available in the
+  reference section.
 
 Most of these elements accept certain optional arguments:
 
--   **color** to specify the color.
+- **color** to specify the color.
 
--   **transmit** specifies the transparency of the element, which by
-    default is 0.
+- **transmit** specifies the transparency of the element, which by
+  default is 0.
 
--   **filter** alternative way of specifying transparency for use with
-    the povray module.
+- **filter** alternative way of specifying transparency for use with
+  the povray module.
 
 Once appropriate elements have been created, we can display the Graphics
 object with `morphoview` using Show.
@@ -115,13 +118,13 @@ creating the Graphics object:
     var dx = 0.125 // Spacing of points to draw
     var eps = 1e-10 // Check for zero separation
 
-    var g = Graphics() 
+    var g = Graphics()
 
 We'll now define the charges by creating two List objects: one contains
 the strength of each charge and the second stores their positions:
 
     // Electric field due to a system of point charges
-    var qq = [1,-1] 
+    var qq = [1,-1]
     var xq = [ Matrix([-R/2, 0, 0]), Matrix([R/2, 0, 0])]
 
 We'll also define a cutoff distance around each charge below which we

--- a/src/visualization/plot_module.md
+++ b/src/visualization/plot_module.md
@@ -1,4 +1,4 @@
-## The plot module 
+## The plot module
 
 <figure id="fig:PlotMesh">
 <div class="centering">
@@ -111,7 +111,7 @@ label="fig:PlotSelection"></span>Using plotselection.</strong>
 boundary.</figcaption>
 </figure>
 
-When setting up a problem in *morpho*, it's very common to use Selection
+When setting up a problem in _morpho_, it's very common to use Selection
 objects to apply Functionals to limited parts of a Mesh. It's essential
 to check that the Selections are correct, and `plotselection` provides
 an easy way to do this. To illustrate this, let's select the lower right
@@ -142,9 +142,11 @@ points,
 
     var m = AreaMesh(fn (u,v) [u, v, 0], -1..1:0.1, -1..1:0.1)
 
-and a corresponding Field object[^6]:
+and a corresponding Field object:
 
     var f = Field(m, fn (x,y,z) sin(Pi*x)*sin(Pi*y))
+
+> It's actually the third lowest energy eigenmode of a square drum, or equivalently the \\((1,1)\\) state of a 2D infinite square well in quantum mechanics.
 
 By default, `plotfield` draws points at which the Field is defined, and
 colors them by the value as in Fig.
@@ -172,8 +174,11 @@ The scalebar is the then supplied as an optional argument to
 The `color` module supplies a number of colormaps that you can try:
 ViridisMap is used by default, but PlasmaMap, MagmaMap and InfernoMap
 are also recommended and have been specially formulated to be accessible
-to users with limited color perception[^7]. GrayMap and HueMap are also
-available.
+to users with limited color perception.
+
+> The _morpho_ versions are adapted from _Simon Garnier, Noam Ross, Robert Rudis, Antônio P. Camargo, Marco Sciaini, and Cédric Scherer (2021). viridis(Lite) - Colorblind-Friendly Color Maps for R. viridis package version 0.6.2._
+
+GrayMap and HueMap are also available.
 
 <figure id="fig:PlotField">
 <div class="centering">

--- a/src/working_with_meshes/meshgen_module.md
+++ b/src/working_with_meshes/meshgen_module.md
@@ -4,17 +4,21 @@ The `meshgen` module conveniently produces high quality meshes for many
 kinds of domain. It follows the builder pattern with a MeshGen helper
 object that performs the construction. To use `meshgen`, the user must
 provide a scalar function that is positive everywhere that they want to
-be meshed[^5]. For example, the interior of the unit disk in two
+be meshed.
+
+> **Note** One example is referred to in the literature as a _signed distance function_, which is the Euclidean distance of a given point \\(x\\) to the boundary of a set \\(\Omega\\) with the sign positive if \\(x\\) is in the interior of \\(\Omega\\). MeshGen does not require signed distance functions, but accepts any continuous and reasonably smooth function.
+
+For example, the interior of the unit disk in two
 dimensions, is described by the function $$f(x,y)=1-(x^{2}+y^{2}).$$ To
-create the corresponding Mesh, we must first specify a suitable *morpho*
+create the corresponding Mesh, we must first specify a suitable _morpho_
 function that describes the domain. This function will be called
 repeatedly by MeshGen, which will pass it a position vector `x`. Hence,
 the \\((x,y)\\) components must be accessed from the argument `x` by
 indexing:
 
 ```javascript
-fn disk(x) { 
-    return 1-(x[0]^2+x[1]^2) 
+fn disk(x) {
+    return 1-(x[0]^2+x[1]^2)
 }
 ```
 
@@ -32,7 +36,7 @@ resolution.
 Finally, we create the Mesh by calling the build method:
 
 ```javascript
-var m = mg.build() 
+var m = mg.build();
 ```
 
 The resulting Mesh is shown in Fig.
@@ -60,7 +64,7 @@ constructor. For example, this code creates an ellipse as shown in Fig.
 [5.2](#fig:MeshGen-2),
 left panel:
 
-    var e0 = Domain(fn (x) -((x[0]/2)^2+x[1]^2-1)) 
+    var e0 = Domain(fn (x) -((x[0]/2)^2+x[1]^2-1))
     var mg = MeshGen(e0, [-2..2:0.2, -1..1:0.2])
     var m = mg.build()
 
@@ -98,7 +102,7 @@ Three dimensional meshes are created very similarly. Here we create a
 spherical mesh, displayed in Fig.
 [5.3](#fig:MeshGen-3)
 
-    var dh = 0.2 
+    var dh = 0.2
     var dom = Domain(fn (x) -(x[0]^2+x[1]^2+x[2]^2-1))
     var mg = MeshGen(dom, [-1..1:dh, -1..1:dh, -1..1:dh])
     var m = mg.build()


### PR DESCRIPTION
Footnotes are not convenient for the web format IMO --- In print, they appear on the same page as the reference, whereas the page size for HTML is not limited, and so the user might need to scroll quite a bit back up to the main text.

Here, I have attempted to replace them with block-quotes. I think it looks quite nice, but not 100% sure whether we should go with this.